### PR TITLE
#63 installing Apache Solr 7.6.0 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/solrcloud-role/tree/develop)
 
+### Changed
+- *[#63](https://github.com/idealista/solrcloud-role/issues/63) Installing Apache Solr 7.6.0 by default* @dortegau
+
 ## [2.0.0](https://github.com/idealista/solrcloud-role/tree/2.0.0) (2018-12-17)
+[Full Changelog](https://github.com/idealista/solrcloud-role/compare/1.9.0...2.0.0)
 ### Added
 - *[#53](https://github.com/idealista/solrcloud-role/issues/53) Adding tasks to manage collections* @dortegau
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ## General
-solr_version: 7.5.0
+solr_version: 7.6.0
 
 ## Service options
 

--- a/molecule/default/group_vars/solrcloud.yml
+++ b/molecule/default/group_vars/solrcloud.yml
@@ -1,6 +1,6 @@
 ---
 
-solr_version: 7.5.0
+solr_version: 7.6.0
 solr_port: 8983
 
 solr_zookeeper_hosts: zookeeper:2181


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Installing Apache Solr 7.6.0 by default

### Applicable Issues

#63 
